### PR TITLE
Add bottom padding to blog for improved mobile view

### DIFF
--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -35,7 +35,7 @@ const Blog = () => {
 
   return (
     <section id="blog" className="section">
-      <div className="mx-auto px-4 py-10">
+      <div className="mx-auto px-4 py-10 pb-40">
         <h1 className="mb-8 font-bold text-3xl tracking-wide text-center text-primary">Blog</h1>
         {loading ? (
           <p className="text-center">Loading...</p>

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -62,7 +62,7 @@ const BlogPost = () => {
   }
 
   return (
-    <article className="mx-auto px-4 py-10 max-w-3xl">
+    <article className="mx-auto px-4 py-10 pb-40 max-w-3xl">
       <Link to="/blog" className="inline-block mb-4 text-zinc-400 hover:text-white">&larr; Back to Blog</Link>
       {postMeta && (
         <div className="mb-6 text-zinc-400 text-sm">


### PR DESCRIPTION
On mobile view, the blog text goes to the bottom of the page, without padding or margin. This means that blog button or the cat overlays with the text, making it unreadable. This PR adds a fixed padding the same size of the cat image height, making the text readable.